### PR TITLE
Fix DropdownItem unexpected keyword argument 'left_meta'

### DIFF
--- a/oai_shell/shell/textual_app.py
+++ b/oai_shell/shell/textual_app.py
@@ -464,7 +464,7 @@ class OAIShellApp(App):
                             # Suggest parameters not yet used
                             param_text = f"--{p['name']}"
                             if param_text not in value:
-                                items.append(DropdownItem(main=value + param_name + " ", left_meta=f"({p['in']})"))
+                                items.append(DropdownItem(main=value + param_name + " "))
         
         # Theme suggestions
         elif value.startswith('/theme ') and len(words) == 2 and not value.endswith(' '):


### PR DESCRIPTION
This PR removes the `left_meta` keyword argument from the `DropdownItem` constructor in `OAIShellApp._get_autocomplete_items`. 

The current version of `textual-autocomplete` (3.0.0a11) does not support this argument, which was causing a `TypeError` during autocompletion.

Closes #5
Generated with [Continue](https://continue.dev)
Co-Authored-By: Continue <noreply@continue.dev>