### PR TITLE
fix(issue-9): make operation nodes terminal in OperationsScreen

### DIFF
--- a/oai_shell/shell/textual_app.py
+++ b/oai_shell/shell/textual_app.py
@@ -1,11 +1,28 @@
 """Textual TUI application for OAI-Shell."""
+
 import json
 import shlex
 from typing import Dict, Any, List, Optional, Tuple
 from textual.app import App, ComposeResult
-from textual.widgets import Header, Footer, Input, RichLog, Static, DataTable, Tree, Label, Button
+from textual.widgets import (
+    Header,
+    Footer,
+    Input,
+    RichLog,
+    Static,
+    DataTable,
+    Tree,
+    Label,
+    Button,
+)
 from textual.widgets.tree import TreeNode
-from textual.containers import Container, Horizontal, Vertical, VerticalScroll, ScrollableContainer
+from textual.containers import (
+    Container,
+    Horizontal,
+    Vertical,
+    VerticalScroll,
+    ScrollableContainer,
+)
 from textual.binding import Binding
 from textual.suggester import Suggester
 from textual.screen import ModalScreen
@@ -24,59 +41,58 @@ from ..config.models import ShellConfig
 
 class OAIShellSuggester(Suggester):
     """Custom suggester for OAI-Shell commands and operations."""
-    
+
     def __init__(self, engine: OpenAIEngine, config: ShellConfig):
         self.engine = engine
         self.config = config
         super().__init__(use_cache=False, case_sensitive=False)
-    
+
     async def get_suggestion(self, value: str) -> Optional[str]:
         """Get command suggestions based on current input."""
         if not value:
             return None
-        
+
         words = value.split()
-        
+
         # Suggest commands that start with /
-        if value.startswith('/') and (len(words) <= 1 or ' ' not in value):
-            internals = [
-                '/help', '/exit', '/state', '/operations', 
-                '/call', '/theme'
-            ]
+        if value.startswith("/") and (len(words) <= 1 or " " not in value):
+            internals = ["/help", "/exit", "/state", "/operations", "/call", "/theme"]
             custom = list(self.config.commands.keys())
             all_cmds = internals + custom
-            
+
             for cmd in all_cmds:
                 if cmd.startswith(value) and cmd != value:
                     return cmd
-        
+
         # Suggest operation IDs after /call
-        elif value.startswith('/call ') and len(words) == 2 and not value.endswith(' '):
+        elif value.startswith("/call ") and len(words) == 2 and not value.endswith(" "):
             prefix = words[1]
             for op_id in self.engine.operations.keys():
                 if op_id.lower().startswith(prefix.lower()) and op_id != prefix:
-                    return f'/call {op_id}'
-        
+                    return f"/call {op_id}"
+
         return None
 
 
 class StatePanel(Static):
     """Widget to display current state variables."""
-    
+
     def __init__(self, state: ClientState, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.state = state
-    
+
     def on_mount(self) -> None:
         """Update the state display when mounted."""
         self.update_display()
-    
+
     def update_display(self) -> None:
         """Update the state panel with current values."""
-        table = RichTable(title="[bold cyan]State[/bold cyan]", box=None, padding=(0, 1))
+        table = RichTable(
+            title="[bold cyan]State[/bold cyan]", box=None, padding=(0, 1)
+        )
         table.add_column("Key", style="yellow")
         table.add_column("Value", style="green")
-        
+
         state_dict = self.state.to_dict()
         if not state_dict:
             self.update("[dim]No state variables set[/dim]")
@@ -88,12 +104,12 @@ class StatePanel(Static):
 
 class OperationsScreen(ModalScreen):
     """Modal screen for interactive operations explorer."""
-    
+
     BINDINGS = [
         Binding("escape", "dismiss", "Close"),
         Binding("q", "dismiss", "Close"),
     ]
-    
+
     CSS = """
     OperationsScreen {
         align: center middle;
@@ -131,39 +147,44 @@ class OperationsScreen(ModalScreen):
         background: $surface;
     }
     """
-    
+
     def __init__(self, engine: OpenAIEngine, config: ShellConfig, state: ClientState):
         super().__init__()
         self.engine = engine
         self.config = config
         self.state = state
         self.selected_operation = None
-    
+
     def compose(self) -> ComposeResult:
         """Compose the operations explorer UI."""
         with Container(id="operations_container"):
             with Horizontal():
                 yield ScrollableContainer(
-                    Tree("API Operations", id="operations_tree"),
-                    id="tree_container"
+                    Tree("API Operations", id="operations_tree"), id="tree_container"
                 )
                 yield ScrollableContainer(
-                    Static("Select an operation to view request schema", id="request_content"),
-                    id="request_panel"
+                    Static(
+                        "Select an operation to view request schema",
+                        id="request_content",
+                    ),
+                    id="request_panel",
                 )
                 yield ScrollableContainer(
-                    Static("Select an operation to view response schema", id="response_content"),
-                    id="response_panel"
+                    Static(
+                        "Select an operation to view response schema",
+                        id="response_content",
+                    ),
+                    id="response_panel",
                 )
-    
+
     def on_mount(self) -> None:
         """Build the operations tree when mounted."""
         tree = self.query_one("#operations_tree", Tree)
         tree.show_root = False
-        
+
         depth = self.config.tui.aggregation_depth
         tag_groups: Dict[str, Dict[str, List[Tuple[str, Dict[str, Any]]]]] = {}
-        
+
         # Group operations by tag and path
         for op_id, op in self.engine.operations.items():
             tags = op["raw"].get("tags", ["default"])
@@ -171,15 +192,15 @@ class OperationsScreen(ModalScreen):
                 if tag not in tag_groups:
                     tag_groups[tag] = {}
                 path = op.get("display_path", op["path"])
-                parts = path.strip('/').split('/')
+                parts = path.strip("/").split("/")
                 if depth > 0 and len(parts) > depth:
-                    group_path = '/' + '/'.join(parts[:depth]) + '/...'
+                    group_path = "/" + "/".join(parts[:depth]) + "/..."
                 else:
                     group_path = path
                 if group_path not in tag_groups[tag]:
                     tag_groups[tag][group_path] = []
                 tag_groups[tag][group_path].append((op_id, op))
-        
+
         # Build tree structure
         for tag in sorted(tag_groups.keys()):
             display_tag = tag
@@ -187,61 +208,76 @@ class OperationsScreen(ModalScreen):
                 display_tag = f"{tag} ({self.engine.common_prefix})"
             tag_node = tree.root.add(display_tag, expand=True)
             tag_node.data = {"type": "tag", "name": tag}
-            
+
             paths = tag_groups[tag]
             for path in sorted(paths.keys()):
                 path_node = tag_node.add(path, expand=False)
                 path_node.data = {"type": "path", "name": path}
-                
+
                 for op_id, op in sorted(paths[path], key=lambda x: x[0]):
                     method = op["method"]
                     method_style = {
                         "GET": "green",
-                        "POST": "yellow", 
+                        "POST": "yellow",
                         "PUT": "blue",
-                        "DELETE": "red"
+                        "DELETE": "red",
                     }.get(method, "white")
-                    op_node = path_node.add(f"[{method_style}]{method}[/{method_style}] {op_id}")
+                    # Use add_leaf for operation nodes so they are terminal (not expandable)
+                    try:
+                        # Terminal operation node so it can't be expanded in the tree.
+                        # This addresses issue #9: endpoints should be terminal nodes.
+                        op_node = path_node.add_leaf(
+                            f"[{method_style}]{method}[/{method_style}] {op_id}"
+                        )
+                    except Exception:
+                        # Fallback for older textual versions where add_leaf may not exist
+                        op_node = path_node.add(
+                            f"[{method_style}]{method}[/{method_style}] {op_id}"
+                        )
                     op_node.data = {"type": "op", "op_id": op_id, "op": op}
-    
+
     def on_tree_node_selected(self, event: Tree.NodeSelected) -> None:
         """Handle tree node selection."""
         node = event.node
         if not node.data or node.data.get("type") != "op":
             return
-        
+
         op_id = node.data["op_id"]
         op = node.data["op"]
         self.selected_operation = op_id
-        
+
         # Update request panel
         self._update_request_panel(op)
-        
+
         # Update response panel
         self._update_response_panel(op)
-    
-    def _build_schema_tree(self, schema: Dict[str, Any], name: str = "root") -> RichTree:
+
+    def _build_schema_tree(
+        self, schema: Dict[str, Any], name: str = "root"
+    ) -> RichTree:
         """Build a Rich tree from a schema."""
         schema = self.engine.resolve_schema(schema)
         s_type = schema.get("type", "object")
         description = schema.get("description", "")
-        
+
         type_col = {
             "object": "blue",
             "array": "yellow",
             "string": "green",
             "integer": "cyan",
             "number": "cyan",
-            "boolean": "magenta"
+            "boolean": "magenta",
         }.get(s_type, "white")
-        
-        icon = self.config.tui.type_icons.get(s_type, self.config.tui.type_icons.get("default", ""))
+
+        icon = self.config.tui.type_icons.get(
+            s_type, self.config.tui.type_icons.get("default", "")
+        )
         label = f"{icon} [bold cyan]{name}[/bold cyan] [dim][{type_col}]({s_type})[/{type_col}][/dim]"
         if description:
             label += f" - [italic]{description}[/italic]"
-        
+
         res_tree = RichTree(label)
-        
+
         if s_type == "object":
             props = schema.get("properties", {})
             required = schema.get("required", [])
@@ -255,24 +291,26 @@ class OperationsScreen(ModalScreen):
             items = schema.get("items", {})
             sub_tree = self._build_schema_tree(items, "items[]")
             res_tree.add(sub_tree)
-        
+
         return res_tree
-    
+
     def _update_request_panel(self, op: Dict[str, Any]) -> None:
         """Update the request schema panel."""
         req_content = []
-        
+
         # Parameters
         params = []
         for p in op.get("parameters", []):
-            params.append({
-                "name": p["name"],
-                "in": p.get("in", "query"),
-                "type": p.get("schema", {}).get("type", "string"),
-                "required": p.get("required", False),
-                "description": p.get("description", "")
-            })
-        
+            params.append(
+                {
+                    "name": p["name"],
+                    "in": p.get("in", "query"),
+                    "type": p.get("schema", {}).get("type", "string"),
+                    "required": p.get("required", False),
+                    "description": p.get("description", ""),
+                }
+            )
+
         if params:
             table = RichTable(title="Parameters", box=None, padding=(0, 1))
             table.add_column("Name", style="cyan")
@@ -280,38 +318,52 @@ class OperationsScreen(ModalScreen):
             table.add_column("Type", style="magenta")
             table.add_column("Description")
             for p in params:
-                name = f"[bold]{p['name']}*[/bold]" if p["required"] else p['name']
-                table.add_row(name, p["in"], p["type"], p["description"][:40] if p["description"] else "")
+                name = f"[bold]{p['name']}*[/bold]" if p["required"] else p["name"]
+                table.add_row(
+                    name,
+                    p["in"],
+                    p["type"],
+                    p["description"][:40] if p["description"] else "",
+                )
             req_content.append(table)
-        
+
         # Request Body
         body = op.get("requestBody")
         if body:
             content = body.get("content", {})
             json_schema = content.get("application/json", {}).get("schema")
             if json_schema:
-                req_content.append(self._build_schema_tree(json_schema, name="RequestBody (JSON)"))
-        
+                req_content.append(
+                    self._build_schema_tree(json_schema, name="RequestBody (JSON)")
+                )
+
         if not req_content:
             req_content.append("[dim]No request parameters or body[/dim]")
-        
+
         request_static = self.query_one("#request_content", Static)
         request_static.update(Panel(Group(*req_content), title="Request Schema"))
-    
+
     def _update_response_panel(self, op: Dict[str, Any]) -> None:
         """Update the response schema panel."""
         res_200 = op.get("responses", {}).get("200", {})
         res_content_spec = res_200.get("content", {})
         res_json_schema = res_content_spec.get("application/json", {}).get("schema")
-        
+
         if res_json_schema:
-            res_view = self._build_schema_tree(res_json_schema, name="Response (200 OK)")
+            res_view = self._build_schema_tree(
+                res_json_schema, name="Response (200 OK)"
+            )
             response_static = self.query_one("#response_content", Static)
             response_static.update(Panel(res_view, title="Response Schema"))
         else:
             response_static = self.query_one("#response_content", Static)
-            response_static.update(Panel("[dim]No response schema (application/json) found for 200 OK[/dim]", title="Response Schema"))
-    
+            response_static.update(
+                Panel(
+                    "[dim]No response schema (application/json) found for 200 OK[/dim]",
+                    title="Response Schema",
+                )
+            )
+
     def action_dismiss(self) -> None:
         """Dismiss the modal and return selected operation."""
         if self.selected_operation:
@@ -319,9 +371,12 @@ class OperationsScreen(ModalScreen):
             cmd = f"/call {self.selected_operation}"
             op = self.engine.operations.get(self.selected_operation)
             if op:
-                all_params = self.engine.get_params_for_operation(self.selected_operation)
+                all_params = self.engine.get_params_for_operation(
+                    self.selected_operation
+                )
                 required_missing = [
-                    p["name"] for p in all_params 
+                    p["name"]
+                    for p in all_params
                     if p.get("required") and self.state.get(p["name"]) is None
                 ]
                 for p_name in required_missing:
@@ -336,18 +391,18 @@ class OAIShellAutoComplete(AutoComplete):
 
     def get_search_string(self, target_state) -> str:
         """The search string is just the word currently being typed."""
-        before_cursor = target_state.text[:target_state.cursor_position]
+        before_cursor = target_state.text[: target_state.cursor_position]
         if not before_cursor or before_cursor.endswith(" "):
             return ""
-        
+
         last_word = before_cursor.split()[-1]
         return last_word
 
     def apply_completion(self, value: str, state) -> None:
         """Insert ONLY the completion part, replacing the current word."""
         target = self.target
-        before_cursor = state.text[:state.cursor_position]
-        
+        before_cursor = state.text[: state.cursor_position]
+
         # Find the start of the word being replaced
         if not before_cursor or before_cursor.endswith(" "):
             # We are inserting at cursor (e.g. after a space)
@@ -356,15 +411,18 @@ class OAIShellAutoComplete(AutoComplete):
             # We are replacing the current word
             last_space_idx = before_cursor.rfind(" ")
             word_start = last_space_idx + 1 if last_space_idx != -1 else 0
-            
+
             # Update target value by replacing the word segment
-            new_text = state.text[:word_start] + value + state.text[state.cursor_position:]
+            new_text = (
+                state.text[:word_start] + value + state.text[state.cursor_position :]
+            )
             target.value = new_text
             target.cursor_position = word_start + len(value)
 
+
 class OAIShellApp(App):
     """Textual TUI application for OAI-Shell."""
-    
+
     CSS = """
     .main-screen {
         layout: grid;
@@ -416,12 +474,12 @@ class OAIShellApp(App):
         max-width: 80;
     }
     """
-    
+
     BINDINGS = [
         Binding("ctrl+c", "quit", "Quit", priority=True),
         Binding("ctrl+d", "quit", "Quit"),
     ]
-    
+
     def __init__(self, config: ShellConfig, engine: OpenAIEngine):
         super().__init__()
         self.config = config
@@ -433,109 +491,118 @@ class OAIShellApp(App):
         self.title = config.name
         self.sub_title = f"Connected to {engine.base_url}"
         self._current_theme_name = "dark"  # Default theme name
-    
+
     def compose(self) -> ComposeResult:
         """Create child widgets for the app."""
         yield Header(show_clock=True)
         yield StatePanel(self.state, id="state_panel")
         yield RichLog(id="output_log", highlight=True, markup=True, wrap=True)
-        
+
         # Create input with autocomplete
         input_widget = Input(
             placeholder="Enter command (e.g., /help, /operations, /call ...)",
-            id="command_input"
+            id="command_input",
         )
-        
+
         yield Container(input_widget, id="input_container")
-        
+
         # Add autocomplete overlay
         yield OAIShellAutoComplete(
-            target="#command_input",
-            candidates=self._get_autocomplete_items
+            target="#command_input", candidates=self._get_autocomplete_items
         )
-    
+
     def _get_autocomplete_items(self, input_state) -> List[DropdownItem]:
         """Generate autocomplete items based on current input."""
         value = input_state.text
         cursor_pos = input_state.cursor_position
-        
+
         if not value:
             return []
-        
+
         # Context before and after cursor
         before_cursor = value[:cursor_pos]
         after_cursor = value[cursor_pos:]
         words_before = before_cursor.split()
-        
+
         # Determine the word currently being typed
-        if not before_cursor or before_cursor.endswith(' '):
+        if not before_cursor or before_cursor.endswith(" "):
             last_word = ""
         else:
             last_word = words_before[-1]
-        
+
         items = []
-        
+
         # 1. Command suggestions (at the very beginning)
-        if len(words_before) == 0 or (len(words_before) == 1 and not before_cursor.endswith(' ')):
-            internals = [
-                '/help', '/exit', '/state', '/operations', '/call', '/theme'
-            ]
+        if len(words_before) == 0 or (
+            len(words_before) == 1 and not before_cursor.endswith(" ")
+        ):
+            internals = ["/help", "/exit", "/state", "/operations", "/call", "/theme"]
             custom = list(self.config.commands.keys())
             all_cmds = internals + custom
-            
+
             for cmd in all_cmds:
                 if cmd.startswith(last_word):
                     # We only suggest the command itself, not the full line
                     items.append(DropdownItem(main=cmd))
-        
+
         # 2. Operation IDs after /call
-        elif words_before and words_before[0] == '/call':
-            if (len(words_before) == 1 and before_cursor.endswith(' ')) or \
-               (len(words_before) == 2 and not before_cursor.endswith(' ')):
+        elif words_before and words_before[0] == "/call":
+            if (len(words_before) == 1 and before_cursor.endswith(" ")) or (
+                len(words_before) == 2 and not before_cursor.endswith(" ")
+            ):
                 # Typing the operation ID
                 for op_id in sorted(self.engine.operations.keys()):
                     if op_id.lower().startswith(last_word.lower()):
                         items.append(DropdownItem(main=op_id))
-            
+
             # 3. Parameter suggestions after /call <op_id>
             elif len(words_before) >= 2:
                 op_id = words_before[1]
                 if op_id in self.engine.operations:
                     all_params = self.engine.get_params_for_operation(op_id)
-                    
+
                     # Filter out parameters already present in the full command
-                    all_words = value.replace('=', ' ').split()
-                    used_params = {w.lstrip('-') for w in all_words if w.startswith('--')}
-                    
+                    all_words = value.replace("=", " ").split()
+                    used_params = {
+                        w.lstrip("-") for w in all_words if w.startswith("--")
+                    }
+
                     # If typing a parameter, don't filter it out
-                    current_param_typing = last_word.replace('=', ' ').split()[0].lstrip('-') if last_word.startswith('--') else None
-                    
+                    current_param_typing = (
+                        last_word.replace("=", " ").split()[0].lstrip("-")
+                        if last_word.startswith("--")
+                        else None
+                    )
+
                     for p in all_params:
-                        param_name = p['name']
+                        param_name = p["name"]
                         full_param = f"--{param_name}"
-                        
-                        if param_name in used_params and param_name != current_param_typing:
+
+                        if (
+                            param_name in used_params
+                            and param_name != current_param_typing
+                        ):
                             continue
-                        
+
                         if full_param.startswith(last_word):
-                            type_hint = p.get('type', 'any')
+                            type_hint = p.get("type", "any")
                             prefix_text = f"({p['in']}) {type_hint}"
-                            items.append(DropdownItem(
-                                main=full_param, 
-                                prefix=prefix_text
-                            ))
-        
+                            items.append(
+                                DropdownItem(main=full_param, prefix=prefix_text)
+                            )
+
         # 4. Theme suggestions
-        elif words_before and words_before[0] == '/theme':
-            themes = ['dark', 'light', 'dark-high-contrast']
-            if (len(words_before) == 1 and before_cursor.endswith(' ')) or \
-               (len(words_before) == 2 and not before_cursor.endswith(' ')):
+        elif words_before and words_before[0] == "/theme":
+            themes = ["dark", "light", "dark-high-contrast"]
+            if (len(words_before) == 1 and before_cursor.endswith(" ")) or (
+                len(words_before) == 2 and not before_cursor.endswith(" ")
+            ):
                 for theme in themes:
                     if theme.startswith(last_word.lower()):
                         items.append(DropdownItem(main=theme))
-        
+
         return items[:15]
-    
+
     def on_mount(self) -> None:
         """Initialize the app when mounted."""
         # Add a class to the screen to apply the layout, since id cannot be changed after initialization
@@ -547,10 +614,10 @@ class OAIShellApp(App):
                 f"Connected to {self.engine.base_url}\n\n"
                 f"Type [cyan]/help[/cyan] for available commands",
                 title="OAI-Shell",
-                border_style="green"
+                border_style="green",
             )
         )
-        
+
         # Validate configured commands at startup
         for cmd_name, cmd_conf in self.config.commands.items():
             op = self.engine.operations.get(cmd_conf.operationId)
@@ -560,34 +627,36 @@ class OAIShellApp(App):
                     "Validation skipped.[/dim yellow]"
                 )
                 continue
-            
+
             # Validate default_response_field
             if cmd_conf.default_response_field and not cmd_conf.force_response_field:
                 resp_200 = op.get("responses", {}).get("200", {})
                 content = resp_200.get("content", {})
                 json_schema = content.get("application/json", {}).get("schema")
                 if json_schema:
-                    if not SchemaPathResolver.validate_path(json_schema, cmd_conf.default_response_field, self.engine):
+                    if not SchemaPathResolver.validate_path(
+                        json_schema, cmd_conf.default_response_field, self.engine
+                    ):
                         output_log.write(
                             f"[yellow]Warning:[/yellow] Command '{cmd_name}' has default_response_field "
                             f"'{cmd_conf.default_response_field}' which may not exist in the schema."
                         )
-        
+
         # Focus on input
         self.query_one("#command_input", Input).focus()
-    
+
     async def on_input_submitted(self, event: Input.Submitted) -> None:
         """Handle command submission."""
         command = event.value.strip()
         if not command:
             return
-        
+
         output_log = self.query_one("#output_log", RichLog)
         output_log.write(f"[bold blue]> {command}[/bold blue]")
-        
+
         # Clear input
         event.input.value = ""
-        
+
         # Handle commands
         if command == "/exit":
             self.exit()
@@ -595,16 +664,16 @@ class OAIShellApp(App):
             await self.handle_command(command)
         else:
             output_log.write("[dim]Use /command or /call. Type /help for list.[/dim]")
-    
+
     async def handle_command(self, line: str):
         """Handle slash commands."""
         output_log = self.query_one("#output_log", RichLog)
-        
+
         try:
             parts = shlex.split(line)
             cmd = parts[0]
             args = parts[1:]
-            
+
             if cmd == "/help":
                 self.show_help()
             elif cmd == "/operations":
@@ -621,23 +690,25 @@ class OAIShellApp(App):
                 output_log.write(f"[yellow]Unknown command: {cmd}[/yellow]")
         except Exception as e:
             output_log.write(f"[red]Error:[/red] {e}")
-    
+
     def show_help(self):
         """Display help information."""
         output_log = self.query_one("#output_log", RichLog)
-        
+
         table = RichTable(title="Internal Commands", box=None, padding=(0, 1))
         table.add_column("Command", style="cyan")
         table.add_column("Description")
         table.add_row("/help", "Show this help")
         table.add_row("/operations", "Interactive API operations explorer")
         table.add_row("/state", "Show current state")
-        table.add_row("/theme <name>", "Change color theme (dark, light, dark-high-contrast)")
+        table.add_row(
+            "/theme <name>", "Change color theme (dark, light, dark-high-contrast)"
+        )
         table.add_row("/call <op_id>", "Call a raw API operation")
         table.add_row("/exit", "Exit the shell")
-        
+
         output_log.write(table)
-        
+
         if self.config.commands:
             table2 = RichTable(title="Custom Commands", box=None, padding=(0, 1))
             table2.add_column("Command", style="cyan")
@@ -645,52 +716,63 @@ class OAIShellApp(App):
             for cmd, conf in self.config.commands.items():
                 table2.add_row(cmd, conf.description or "")
             output_log.write(table2)
-    
+
     async def show_operations_interactive(self):
         """Show interactive operations explorer modal."""
+
         def handle_result(result):
             if result:
                 # Set the returned command in the input
                 input_widget = self.query_one("#command_input", Input)
                 input_widget.value = result
                 input_widget.focus()
-        
-        await self.push_screen(OperationsScreen(self.engine, self.config, self.state), handle_result)
-    
+
+        await self.push_screen(
+            OperationsScreen(self.engine, self.config, self.state), handle_result
+        )
+
     def handle_theme(self, args: List[str]):
         """Handle theme changing."""
         output_log = self.query_one("#output_log", RichLog)
-        
+
         if not args:
-            output_log.write(f"[yellow]Current theme:[/yellow] {self._current_theme_name}")
-            output_log.write("[cyan]Available themes:[/cyan] dark, light, dark-high-contrast")
+            output_log.write(
+                f"[yellow]Current theme:[/yellow] {self._current_theme_name}"
+            )
+            output_log.write(
+                "[cyan]Available themes:[/cyan] dark, light, dark-high-contrast"
+            )
             return
-        
+
         theme_name = args[0].lower()
         valid_themes = {
-            'dark': 'textual-dark',
-            'light': 'textual-light',
-            'dark-high-contrast': 'textual-dark-high-contrast'
+            "dark": "textual-dark",
+            "light": "textual-light",
+            "dark-high-contrast": "textual-dark-high-contrast",
         }
-        
+
         if theme_name not in valid_themes:
             output_log.write(f"[red]Invalid theme:[/red] {theme_name}")
-            output_log.write("[cyan]Available themes:[/cyan] dark, light, dark-high-contrast")
+            output_log.write(
+                "[cyan]Available themes:[/cyan] dark, light, dark-high-contrast"
+            )
             return
-        
+
         self.theme = valid_themes[theme_name]
         self._current_theme_name = theme_name
         output_log.write(f"[green]Theme changed to:[/green] {theme_name}")
-    
+
     def show_state(self):
         """Display current state."""
         state_panel = self.query_one("#state_panel", StatePanel)
         state_panel.update_display()
-        
+
         output_log = self.query_one("#output_log", RichLog)
         output_log.write("[green]State panel updated[/green]")
-    
-    def _parse_cli_args(self, args: List[str]) -> Tuple[Dict[str, Any], List[str], bool, bool]:
+
+    def _parse_cli_args(
+        self, args: List[str]
+    ) -> Tuple[Dict[str, Any], List[str], bool, bool]:
         """Parse CLI arguments into parameters."""
         params = {}
         pos_args = []
@@ -706,8 +788,8 @@ class OAIShellApp(App):
                 i += 1
             elif args[i].startswith("--"):
                 key = args[i][2:]
-                if i + 1 < len(args) and not args[i+1].startswith("--"):
-                    params[key] = args[i+1]
+                if i + 1 < len(args) and not args[i + 1].startswith("--"):
+                    params[key] = args[i + 1]
                     i += 2
                 else:
                     params[key] = True
@@ -716,56 +798,66 @@ class OAIShellApp(App):
                 pos_args.append(args[i])
                 i += 1
         return params, pos_args, stream, debug
-    
+
     async def handle_call(self, args: List[str]):
         """Handle /call command."""
         output_log = self.query_one("#output_log", RichLog)
-        
+
         if not args:
-            output_log.write("[red]Usage: /call <operation_id> [--param value] [--stream] [--debug][/red]")
+            output_log.write(
+                "[red]Usage: /call <operation_id> [--param value] [--stream] [--debug][/red]"
+            )
             return
-        
+
         op_id = args[0]
         cli_params, _, stream, debug = self._parse_cli_args(args[1:])
         await self._execute_call(op_id, cli_params, stream=stream, debug=debug)
-    
+
     async def handle_custom_command(self, cmd: str, args: List[str]):
         """Handle custom commands from config."""
         conf = self.config.commands[cmd]
         op_id = conf.operationId
-        
+
         cli_flags, pos_args, stream, debug = self._parse_cli_args(args)
-        
+
         # Build params from mapping using positional args
         cli_params = {}
         for key, template in conf.mapping.items():
             cli_params[key] = self.assembler.resolve_value(template, pos_args)
-        
+
         # Merge CLI flags (they take precedence)
         cli_params.update(cli_flags)
-        
-        await self._execute_call(op_id, cli_params, stream=stream, debug=debug, cmd_conf=conf)
-    
+
+        await self._execute_call(
+            op_id, cli_params, stream=stream, debug=debug, cmd_conf=conf
+        )
+
     async def _execute_call(
-        self, 
-        op_id: str, 
-        cli_params: Dict[str, Any], 
-        stream: bool = False, 
+        self,
+        op_id: str,
+        cli_params: Dict[str, Any],
+        stream: bool = False,
         debug: bool = False,
-        cmd_conf = None
+        cmd_conf=None,
     ):
         """Execute an API call."""
         output_log = self.query_one("#output_log", RichLog)
-        
+
         try:
             payload, autofilled = self.assembler.assemble(op_id, cli_params)
-            
+
             # Notify autofilled params
             for key in autofilled:
-                output_log.write(f"[dim italic]Autofilled from state: {key}[/dim italic]")
-            
+                output_log.write(
+                    f"[dim italic]Autofilled from state: {key}[/dim italic]"
+                )
+
             # Validate default_response_field
-            if cmd_conf and cmd_conf.default_response_field and not cmd_conf.force_response_field:
+            if (
+                cmd_conf
+                and cmd_conf.default_response_field
+                and not cmd_conf.force_response_field
+            ):
                 op = self.engine.operations.get(op_id)
                 if op:
                     resp_200 = op.get("responses", {}).get("200", {})
@@ -781,7 +873,7 @@ class OAIShellApp(App):
                                 "Use force_response_field: true to override."
                             )
                             return
-            
+
             if stream:
                 with self.engine.call(op_id, stream=True, **payload) as resp:
                     output_log.write("[bold blue]Streaming Response:[/bold blue]")
@@ -791,7 +883,7 @@ class OAIShellApp(App):
             else:
                 resp = self.engine.call(op_id, **payload)
                 data = resp.json()
-                
+
                 # Render response
                 if cmd_conf and cmd_conf.formatting:
                     self._render_formatted_response(data, cmd_conf.formatting, debug)
@@ -799,9 +891,11 @@ class OAIShellApp(App):
                     # Default rendering
                     display_data = data
                     title = "[bold blue]Response[/bold blue]"
-                    
+
                     if cmd_conf and cmd_conf.default_response_field:
-                        resolved = SchemaPathResolver.resolve_data(data, cmd_conf.default_response_field)
+                        resolved = SchemaPathResolver.resolve_data(
+                            data, cmd_conf.default_response_field
+                        )
                         if resolved is not None:
                             display_data = resolved
                             title = f"[bold blue]Response: {cmd_conf.default_response_field}[/bold blue]"
@@ -810,24 +904,32 @@ class OAIShellApp(App):
                                 f"[yellow]Warning: Field '{cmd_conf.default_response_field}' "
                                 "not found in the response payload.[/yellow]"
                             )
-                    
+
                     output_log.write(
                         Panel(
-                            Syntax(json.dumps(display_data, indent=2), "json", background_color="default"),
+                            Syntax(
+                                json.dumps(display_data, indent=2),
+                                "json",
+                                background_color="default",
+                            ),
                             title=title,
-                            border_style="green"
+                            border_style="green",
                         )
                     )
-                    
+
                     if debug:
                         output_log.write(
                             Panel(
-                                Syntax(json.dumps(data, indent=2), "json", background_color="default"),
+                                Syntax(
+                                    json.dumps(data, indent=2),
+                                    "json",
+                                    background_color="default",
+                                ),
                                 title="[bold yellow]Raw Response (Debug)[/bold yellow]",
-                                border_style="dim"
+                                border_style="dim",
                             )
                         )
-                
+
                 # After call hooks
                 if cmd_conf and cmd_conf.after_call:
                     save = cmd_conf.after_call.get("save_to_state", {})
@@ -837,57 +939,65 @@ class OAIShellApp(App):
                             val = SchemaPathResolver.resolve_data(data, key_path)
                             if val is not None:
                                 self.state.update(**{state_key: val})
-                                output_log.write(f"[dim]State updated: {state_key}[/dim]")
+                                output_log.write(
+                                    f"[dim]State updated: {state_key}[/dim]"
+                                )
                                 # Update state panel
                                 state_panel = self.query_one("#state_panel", StatePanel)
                                 state_panel.update_display()
-        
+
         except EngineError as e:
             output_log.write(f"[red]API Error:[/red] {e}")
         except Exception as e:
             output_log.write(f"[red]Error:[/red] {e}")
-    
+
     def _render_formatted_response(self, data: Any, formatting, debug: bool = False):
         """Render response with custom formatting."""
         output_log = self.query_one("#output_log", RichLog)
-        
+
         title = formatting.title or "[bold blue]Response[/bold blue]"
         blocks_content = []
-        
+
         for block in formatting.blocks:
             block_data = SchemaPathResolver.resolve_data(data, block.path)
             if block_data is None:
                 if block.optional:
                     continue
                 block_data = {}
-            
+
             if block.title:
                 blocks_content.append(f"[bold underline]{block.title}[/bold underline]")
-            
+
             if block.layout == "table":
                 blocks_content.append(self._get_table(block_data, block.fields))
             elif block.layout == "markdown":
                 blocks_content.append(Markdown(str(block_data)))
             elif block.layout == "json":
                 blocks_content.append(
-                    Syntax(json.dumps(block_data, indent=2), "json", background_color="default")
+                    Syntax(
+                        json.dumps(block_data, indent=2),
+                        "json",
+                        background_color="default",
+                    )
                 )
             else:
                 blocks_content.extend(self._get_list_items(block_data, block.fields))
-            
+
             blocks_content.append("")
-        
+
         output_log.write(Panel(Group(*blocks_content), title=title))
-        
+
         if debug:
             output_log.write(
                 Panel(
-                    Syntax(json.dumps(data, indent=2), "json", background_color="default"),
+                    Syntax(
+                        json.dumps(data, indent=2), "json", background_color="default"
+                    ),
                     title="[bold yellow]Raw Response (Debug)[/bold yellow]",
-                    border_style="dim"
+                    border_style="dim",
                 )
             )
-    
+
     def _get_list_items(self, data: Any, fields: List[Any]) -> List[Any]:
         """Get list items for rendering."""
         items = []
@@ -895,25 +1005,25 @@ class OAIShellApp(App):
             val = SchemaPathResolver.resolve_data(data, field.path)
             if val is None and field.optional:
                 continue
-            
+
             label = field.label or field.path
             rendered_val = self._format_value(val, field.format, field.style)
-            
+
             if field.format == "text":
                 items.append(f"[bold]{label}:[/bold] {rendered_val}")
             else:
                 items.append(f"[bold]{label}:[/bold]")
                 items.append(rendered_val)
         return items
-    
+
     def _get_table(self, data: Any, fields: List[Any]) -> RichTable:
         """Create a Rich table from data."""
         rows = data if isinstance(data, list) else [data]
-        
+
         table = RichTable(box=None, padding=(0, 1))
         for field in fields:
             table.add_column(field.label or field.path, style=field.style)
-        
+
         for row in rows:
             row_vals = []
             for field in fields:
@@ -921,12 +1031,12 @@ class OAIShellApp(App):
                 row_vals.append(str(val) if val is not None else "")
             table.add_row(*row_vals)
         return table
-    
+
     def _format_value(self, val: Any, format_type: str, style: Optional[str]) -> Any:
         """Format a value for display."""
         if val is None:
             return "[dim]null[/dim]"
-        
+
         if format_type == "json":
             return Syntax(json.dumps(val, indent=2), "json", background_color="default")
         elif format_type == "markdown":


### PR DESCRIPTION
## Summary

Make operation nodes in the OperationsScreen tree terminal leaf nodes so they cannot be expanded. Previously operation entries were created with Tree.add(), which makes them expandable; this resulted in non-terminal operation nodes in the Textual operations explorer.

This patch uses Tree.add_leaf(...) to add operation nodes. A fallback to Tree.add(...) is included for compatibility with older Textual versions that do not implement add_leaf().

## Changes
- oai_shell/shell/textual_app.py
  - Use add_leaf() for operation nodes with a fallback to add() when add_leaf is unavailable.
  - No other behavior changes; selection handling and panels remain unchanged.

## Rationale
This fixes issue #9 where endpoints in the OperationScreen were not terminal nodes and could be expanded unexpectedly.

Closes #9
